### PR TITLE
Fix compilation on generic arm64 target (gcc)

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -92,7 +92,6 @@ if (use_arm_neon_optimizations) {
       # https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/AArch64-Options.html
       # https://en.wikipedia.org/wiki/Comparison_of_ARMv8-A_cores will list some cores and their arm revision
 
-      defines = [ ]
       if (is_clang) {
         defines += [ "CRC32_ARMV8_CRC32" ]
       }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -91,7 +91,6 @@ if (use_arm_neon_optimizations) {
       #
       # https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/AArch64-Options.html
       # https://en.wikipedia.org/wiki/Comparison_of_ARMv8-A_cores will list some cores and their arm revision
-
       if (is_clang) {
         defines += [ "CRC32_ARMV8_CRC32" ]
       }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -79,6 +79,8 @@ if (use_arm_neon_optimizations) {
     #  "All implementations of the ARMv8.1 architecture are required to
     #   implement the CRC32* instructions. These are optional in ARMv8.0."
     if (!is_ios) {
+      defines = []
+
       # Properly detecting if the CRC32 extension is present either requires
       # to know the exact ARM version or the possibility to test if the
       # compiler knows about those instructions.

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -83,9 +83,9 @@ if (use_arm_neon_optimizations) {
       # to know the exact ARM version or the possibility to test if the
       # compiler knows about those instructions.
       #
-      # For gcc this mostly will depend on the march configured and thus
-      # indirectly what arm target is desired (generic arm64 can not support
-      # this option(hence disabling it by default) in gcc land
+      # For GCC this mostly will depend on the `-march` configured and thus
+      # indirectly what ARM target is desired in GCC land. The generic ARM64
+      # target can not support this option, hence we disable it by default.
       #
       # https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/AArch64-Options.html
       # https://en.wikipedia.org/wiki/Comparison_of_ARMv8-A_cores will list some cores and their arm revision

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -79,7 +79,22 @@ if (use_arm_neon_optimizations) {
     #  "All implementations of the ARMv8.1 architecture are required to
     #   implement the CRC32* instructions. These are optional in ARMv8.0."
     if (!is_ios) {
-      defines = [ "CRC32_ARMV8_CRC32" ]
+      # Properly detecting if the CRC32 extension is present either requires
+      # to know the exact ARM version or the possibility to test if the
+      # compiler knows about those instructions.
+      #
+      # For gcc this mostly will depend on the march configured and thus
+      # indirectly what arm target is desired (generic arm64 can not support
+      # this option(hence disabling it by default) in gcc land
+      #
+      # https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/AArch64-Options.html
+      # https://en.wikipedia.org/wiki/Comparison_of_ARMv8-A_cores will list some cores and their arm revision
+
+      defines = [ ]
+      if (is_clang) {
+        defines += [ "CRC32_ARMV8_CRC32" ]
+      }
+
       if (is_android) {
         defines += [ "ARMV8_OS_ANDROID" ]
       } else if (is_linux || is_chromeos) {


### PR DESCRIPTION
This commit disables the CRC32 instruction set extension on armv8/gcc. Not all
the armv8 targets have support for the CRC32 instructions hence disabling this
in the generic build is reasonable.